### PR TITLE
fix: adiciona codigo 31 na validação de incidencia de fgts

### DIFF
--- a/jsonSchemes/v_S_01_03_00/evtTabRubrica.schema
+++ b/jsonSchemes/v_S_01_03_00/evtTabRubrica.schema
@@ -67,7 +67,7 @@
                 "codincfgts": {
                     "required": true,
                     "type": "string",
-                    "pattern": "^(00|11|12|21|91|92|93)$"
+                    "pattern": "^(00|11|12|21|31|91|92|93)$"
                 },
                 "codinccprp": {
                     "required": false,


### PR DESCRIPTION
Código de incidência da rubrica para o Fundo de Garantia do Tempo de Serviço - FGTS.
Valores válidos:
00 - Não é base de cálculo do FGTS
11 - Base de cálculo do FGTS mensal
12 - Base de cálculo do FGTS 13° salário
21 - Base de cálculo do FGTS aviso prévio indenizado
31 - Desconto eConsignado
91 - Incidência suspensa em decorrência de decisão judicial - FGTS mensal
92 - Incidência suspensa em decorrência de decisão judicial - FGTS 13º salário